### PR TITLE
Abstract services regenerated because of pagination problem

### DIFF
--- a/src/Actions/Invoices/Pay.php
+++ b/src/Actions/Invoices/Pay.php
@@ -3,7 +3,6 @@
 namespace NextDeveloper\Accounting\Actions\Invoices;
 
 use Carbon\Carbon;
-use GPBMetadata\Google\Api\Auth;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use NextDeveloper\Accounting\Database\Models\CreditCards;
@@ -35,14 +34,23 @@ class Pay extends AbstractAction
         'payment-failed:NextDeveloper\Accounting\Invoices'
     ];
 
+    public const PARAMETERS = [
+        'installment' => [
+            'type'          =>  'integer',
+            'validation'    =>  'nullable|integer'
+        ]
+    ];
+
     /**
      * @param Invoices $invoice
      */
-    public function __construct(Invoices $invoice, ...$args)
+    public function __construct(Invoices $invoice, $params = null)
     {
         $this->model = $invoice;
 
         $this->conversationId = Carbon::now()->timestamp;
+
+        $this->validateParameters(self::PARAMETERS, $params);
     }
 
     public function handle()

--- a/src/Authorization/Roles/AccountingUserRole.php
+++ b/src/Authorization/Roles/AccountingUserRole.php
@@ -54,8 +54,6 @@ class AccountingUserRole extends AbstractRole implements IAuthorizationRole
         ) {
             $builder->where('iam_account_id', UserHelper::currentAccount()->id);
         }
-
-
     }
 
     public function checkPrivileges(Users $users = null)

--- a/src/Database/Filters/AccountsQueryFilter.php
+++ b/src/Database/Filters/AccountsQueryFilter.php
@@ -103,4 +103,5 @@ class AccountsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/CreditCardsQueryFilter.php
+++ b/src/Database/Filters/CreditCardsQueryFilter.php
@@ -133,4 +133,5 @@ class CreditCardsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/InvoiceItemsQueryFilter.php
+++ b/src/Database/Filters/InvoiceItemsQueryFilter.php
@@ -123,4 +123,5 @@ class InvoiceItemsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/InvoicesQueryFilter.php
+++ b/src/Database/Filters/InvoicesQueryFilter.php
@@ -143,4 +143,5 @@ class InvoicesQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/PaymentGatewayMessagesQueryFilter.php
+++ b/src/Database/Filters/PaymentGatewayMessagesQueryFilter.php
@@ -81,4 +81,5 @@ class PaymentGatewayMessagesQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/PaymentGatewaysQueryFilter.php
+++ b/src/Database/Filters/PaymentGatewaysQueryFilter.php
@@ -93,4 +93,5 @@ class PaymentGatewaysQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/PromoCodesQueryFilter.php
+++ b/src/Database/Filters/PromoCodesQueryFilter.php
@@ -110,4 +110,5 @@ class PromoCodesQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/TransactionsQueryFilter.php
+++ b/src/Database/Filters/TransactionsQueryFilter.php
@@ -120,4 +120,5 @@ class TransactionsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Models/Accounts.php
+++ b/src/Database/Models/Accounts.php
@@ -164,4 +164,5 @@ class Accounts extends Model
 
 
 
+
 }

--- a/src/Database/Models/CreditCards.php
+++ b/src/Database/Models/CreditCards.php
@@ -180,4 +180,5 @@ class CreditCards extends Model
 
 
 
+
 }

--- a/src/Database/Models/InvoiceItems.php
+++ b/src/Database/Models/InvoiceItems.php
@@ -165,4 +165,5 @@ class InvoiceItems extends Model
 
 
 
+
 }

--- a/src/Database/Models/Invoices.php
+++ b/src/Database/Models/Invoices.php
@@ -184,4 +184,5 @@ class Invoices extends Model
 
 
 
+
 }

--- a/src/Database/Models/PaymentGatewayMessages.php
+++ b/src/Database/Models/PaymentGatewayMessages.php
@@ -147,4 +147,5 @@ class PaymentGatewayMessages extends Model
 
 
 
+
 }

--- a/src/Database/Models/PaymentGateways.php
+++ b/src/Database/Models/PaymentGateways.php
@@ -155,4 +155,5 @@ class PaymentGateways extends Model
 
 
 
+
 }

--- a/src/Database/Models/PromoCodes.php
+++ b/src/Database/Models/PromoCodes.php
@@ -154,4 +154,5 @@ class PromoCodes extends Model
 
 
 
+
 }

--- a/src/Database/Models/Transactions.php
+++ b/src/Database/Models/Transactions.php
@@ -163,4 +163,5 @@ class Transactions extends Model
 
 
 
+
 }

--- a/src/Http/Controllers/Invoices/InvoicesController.php
+++ b/src/Http/Controllers/Invoices/InvoicesController.php
@@ -41,15 +41,9 @@ class InvoicesController extends AbstractController
      */
     public function getActions()
     {
-        $actions = InvoicesService::getActions();
+        $data = InvoicesService::getActions();
 
-        if($actions) {
-            if(array_key_exists($this->model, $actions)) {
-                return $this->withArray($actions[$this->model]);
-            }
-        }
-
-        return $this->noContent();
+        return ResponsableFactory::makeResponse($this, $data);
     }
 
     /**

--- a/src/Http/Requests/Transactions/TransactionsCreateRequest.php
+++ b/src/Http/Requests/Transactions/TransactionsCreateRequest.php
@@ -18,7 +18,7 @@ class TransactionsCreateRequest extends AbstractFormRequest
         'common_currency_id' => 'required|exists:common_currencies,uuid|uuid',
         'accounting_payment_gateway_id' => 'required|exists:accounting_payment_gateways,uuid|uuid',
         'accounting_account_id' => 'required|exists:accounting_accounts,uuid|uuid',
-        'gateway_response' => 'required|string',
+        'gateway_response' => 'nullable|string',
         'conversation_identifier' => 'required|string',
         'is_pending' => 'boolean',
         ];

--- a/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\Accounts;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class AccountsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractAccountsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Accounts $model
      *
      * @return array
      */
     public function transform(Accounts $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -39,7 +73,91 @@ class AbstractAccountsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Accounts $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Accounts $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Accounts $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Accounts $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Accounts $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Accounts $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Accounts $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Accounts $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Accounts $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractCreditCardsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractCreditCardsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\CreditCards;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class CreditCardsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractCreditCardsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param CreditCards $model
      *
      * @return array
      */
     public function transform(CreditCards $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -46,7 +80,91 @@ class AbstractCreditCardsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(CreditCards $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(CreditCards $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(CreditCards $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(CreditCards $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(CreditCards $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(CreditCards $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(CreditCards $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(CreditCards $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(CreditCards $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractInvoiceItemsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractInvoiceItemsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\InvoiceItems;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class InvoiceItemsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,18 +33,33 @@ class AbstractInvoiceItemsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param InvoiceItems $model
      *
      * @return array
      */
     public function transform(InvoiceItems $model)
     {
-                        $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-                    $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $accountingInvoiceId = \NextDeveloper\Accounting\Database\Models\Invoices::where('id', $model->accounting_invoice_id)->first();
-                    $accountingPromoCodeId = \NextDeveloper\Accounting\Database\Models\PromoCodes::where('id', $model->accounting_promo_code_id)->first();
-                    $accountingAccountId = \NextDeveloper\Accounting\Database\Models\Accounts::where('id', $model->accounting_account_id)->first();
-        
+                                                $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $accountingInvoiceId = \NextDeveloper\Accounting\Database\Models\Invoices::where('id', $model->accounting_invoice_id)->first();
+                                                            $accountingPromoCodeId = \NextDeveloper\Accounting\Database\Models\PromoCodes::where('id', $model->accounting_promo_code_id)->first();
+                                                            $accountingAccountId = \NextDeveloper\Accounting\Database\Models\Accounts::where('id', $model->accounting_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -46,7 +80,91 @@ class AbstractInvoiceItemsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(InvoiceItems $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(InvoiceItems $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(InvoiceItems $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(InvoiceItems $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(InvoiceItems $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(InvoiceItems $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(InvoiceItems $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(InvoiceItems $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(InvoiceItems $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractInvoicesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractInvoicesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\Invoices;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class InvoicesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,17 +33,32 @@ class AbstractInvoicesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Invoices $model
      *
      * @return array
      */
     public function transform(Invoices $model)
     {
-                        $accountingAccountId = \NextDeveloper\Accounting\Database\Models\Accounts::where('id', $model->accounting_account_id)->first();
-                    $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-                    $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-        
+                                                $accountingAccountId = \NextDeveloper\Accounting\Database\Models\Accounts::where('id', $model->accounting_account_id)->first();
+                                                            $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -49,7 +83,91 @@ class AbstractInvoicesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Invoices $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Invoices $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Invoices $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Invoices $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Invoices $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Invoices $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Invoices $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Invoices $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Invoices $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractPaymentGatewayMessagesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractPaymentGatewayMessagesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\PaymentGatewayMessages;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class PaymentGatewayMessagesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,14 +33,29 @@ class AbstractPaymentGatewayMessagesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param PaymentGatewayMessages $model
      *
      * @return array
      */
     public function transform(PaymentGatewayMessages $model)
     {
-                        $accountingPaymentGatewayId = \NextDeveloper\Accounting\Database\Models\PaymentGateways::where('id', $model->accounting_payment_gateway_id)->first();
-        
+                                                $accountingPaymentGatewayId = \NextDeveloper\Accounting\Database\Models\PaymentGateways::where('id', $model->accounting_payment_gateway_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -35,7 +69,91 @@ class AbstractPaymentGatewayMessagesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(PaymentGatewayMessages $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(PaymentGatewayMessages $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(PaymentGatewayMessages $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(PaymentGatewayMessages $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(PaymentGatewayMessages $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(PaymentGatewayMessages $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(PaymentGatewayMessages $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(PaymentGatewayMessages $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(PaymentGatewayMessages $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractPaymentGatewaysTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractPaymentGatewaysTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\PaymentGateways;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class PaymentGatewaysTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractPaymentGatewaysTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param PaymentGateways $model
      *
      * @return array
      */
     public function transform(PaymentGateways $model)
     {
-                        $commonCountryId = \NextDeveloper\Commons\Database\Models\Countries::where('id', $model->common_country_id)->first();
-                    $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-        
+                                                $commonCountryId = \NextDeveloper\Commons\Database\Models\Countries::where('id', $model->common_country_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -39,7 +73,91 @@ class AbstractPaymentGatewaysTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(PaymentGateways $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(PaymentGateways $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(PaymentGateways $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(PaymentGateways $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(PaymentGateways $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(PaymentGateways $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(PaymentGateways $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(PaymentGateways $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(PaymentGateways $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractPromoCodesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractPromoCodesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\PromoCodes;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class PromoCodesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,16 +33,31 @@ class AbstractPromoCodesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param PromoCodes $model
      *
      * @return array
      */
     public function transform(PromoCodes $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                    $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                                                            $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -40,7 +74,91 @@ class AbstractPromoCodesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(PromoCodes $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(PromoCodes $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(PromoCodes $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(PromoCodes $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(PromoCodes $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(PromoCodes $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(PromoCodes $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(PromoCodes $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(PromoCodes $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractTransactionsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTransactionsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Accounting\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Accounting\Database\Models\Transactions;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class TransactionsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,18 +33,33 @@ class AbstractTransactionsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Transactions $model
      *
      * @return array
      */
     public function transform(Transactions $model)
     {
-                        $accountingInvoiceId = \NextDeveloper\Accounting\Database\Models\Invoices::where('id', $model->accounting_invoice_id)->first();
-                    $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-                    $accountingPaymentGatewayId = \NextDeveloper\Accounting\Database\Models\PaymentGateways::where('id', $model->accounting_payment_gateway_id)->first();
-                    $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $accountingAccountId = \NextDeveloper\Accounting\Database\Models\Accounts::where('id', $model->accounting_account_id)->first();
-        
+                                                $accountingInvoiceId = \NextDeveloper\Accounting\Database\Models\Invoices::where('id', $model->accounting_invoice_id)->first();
+                                                            $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                                                            $accountingPaymentGatewayId = \NextDeveloper\Accounting\Database\Models\PaymentGateways::where('id', $model->accounting_payment_gateway_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $accountingAccountId = \NextDeveloper\Accounting\Database\Models\Accounts::where('id', $model->accounting_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -45,7 +79,91 @@ class AbstractTransactionsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Transactions $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Transactions $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Transactions $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Transactions $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Transactions $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Transactions $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Transactions $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Transactions $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Transactions $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -233,8 +233,17 @@ Route::prefix('accounting')->group(
 
 
 
+
+
+
+
+
+
+
+
     }
 );
+
 
 
 

--- a/src/Services/AbstractServices/AbstractAccountsService.php
+++ b/src/Services/AbstractServices/AbstractAccountsService.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Str;
 use NextDeveloper\IAM\Helpers\UserHelper;
-use NextDeveloper\Commons\Common\Cache\CacheHelper;
 use NextDeveloper\Commons\Helpers\DatabaseHelper;
 use NextDeveloper\Accounting\Database\Models\Accounts;
 use NextDeveloper\Accounting\Database\Filters\AccountsQueryFilter;
@@ -158,7 +157,7 @@ class AbstractAccountsService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -168,7 +167,7 @@ class AbstractAccountsService
                 $data['common_currency_id']
             );
         }
-                        
+
         try {
             $model = Accounts::create($data);
         } catch(\Exception $e) {
@@ -221,7 +220,7 @@ class AbstractAccountsService
                 $data['common_currency_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Accounting\Accounts', $model);
 
         try {


### PR DESCRIPTION
Abstract services regenerated because of pagination problem. This problem was creating a security issue. The original was of paginating the objects was with the Laravel Eloquent pagination like $model->paginate(). However this method discards all the security controls added by Builder in AuthorizationRoles. That is why we manually implemented the pagination object.