### PR TITLE
Fix getCredit() reading stale in-memory credit instead of DB value

### DIFF
--- a/src/Helpers/CreditHelper.php
+++ b/src/Helpers/CreditHelper.php
@@ -18,7 +18,7 @@ class CreditHelper
      */
     public static function getCredit(?Accounts $account = null): float
     {
-        $account = self::resolve($account);
+        $account = self::resolve($account)->fresh();
         $credit  = (float) $account->credit;
 
         return self::toUsd($credit, $account);


### PR DESCRIPTION
[Fix getCredit() reading stale in-memory credit instead of DB value](https://github.com/nextdeveloper-nl/accounting/commit/019dad5ab736316dcabb0db7cacd890d50e94dba)